### PR TITLE
(feature) Pass response from tripServer back to client (Closes #50)

### DIFF
--- a/integrationServer/requestHandlers.js
+++ b/integrationServer/requestHandlers.js
@@ -2,25 +2,33 @@ const axios = require('axios');
 const qs = require('qs');
 
 const requestHandler = (request, response) => {
+  const tripServerUrl = 'http://localhost:3001';
+
+  const riskServerUrl = 'http://localhost:3002';
+
   const queryObj = qs.stringify(request.query);
 
   // Send query to trip server
-  axios.get(`/trip?${queryObj}`)
+  axios.get(`${tripServerUrl}/trip?${queryObj}`)
     .then((tripResponse) => {
-      const routeObj = qs.stringify(tripResponse.data);
-      // Pass response from trip server to risk server
-      axios.get(`/risk?${routeObj}`)
-        .then((riskResponse) => {
-          // Send fully decorated object back to client
-          response.status(200).json(riskResponse.data);
-        })
-        .catch((error) => {
-          response.status(502).json({
-            error: {
-              message: 'Failed to retrieve risk rating from risk server',
-            },
-          });
-        });
+      response.status(200).json(tripResponse.data);
+
+      // ====UNCOMMENT ONCE RISK SERVER IS COMPLETE=====
+
+      // const routeObj = qs.stringify(tripResponse.data);
+      // // Pass response from trip server to risk server
+      // axios.get(`${riskServerUrl}/risk?${routeObj}`)
+      //   .then((riskResponse) => {
+      //     // Send fully decorated object back to client
+      //     response.status(200).json(riskResponse.data);
+      //   })
+      //   .catch((error) => {
+      //     response.status(502).json({
+      //       error: {
+      //         message: 'Failed to retrieve risk rating from risk server',
+      //       },
+      //     });
+      //   });
     })
     .catch((error) => {
       response.status(502).json({


### PR DESCRIPTION
Commented out code that would pass the response from the tripServer to the riskServer.
Currently passing the response from the tripServer straight to the client (thus skipping the riskServer)
so that the front-end can work on displaying routes correctly.