### PR TITLE
(test) Remove test for / GET

### DIFF
--- a/integrationServer/spec/serverSpec.js
+++ b/integrationServer/spec/serverSpec.js
@@ -31,12 +31,6 @@ beforeEach(() => {
 
 describe('Integration Server:', () => {
   describe('GET', () => {
-    it('should respond with a 200 status code on / GET', (done) => {
-      request(app)
-        .get('/')
-        .expect(200, done);
-    });
-
     describe('/api', () => {
       it('should respond with a 404 status code on /api GET', (done) => {
         request(app)


### PR DESCRIPTION
This endpoint will serve the /client/build folder. However, it
fails during testing if the build folder has not been created.