### PR TITLE
(feature) Optimize risk profiler

### DIFF
--- a/riskService/db/riskPointController.js
+++ b/riskService/db/riskPointController.js
@@ -66,9 +66,20 @@ const findRiskPointsNear = function findRiskPointsNear(point, distance = 100) {
   }).exec();
 };
 
+const findRiskPointsWithinPolygon = function findRiskPointsWithinPolygon(polygon) {
+  return RiskPoint.find({
+    location: {
+      $geoWithin: {
+        $geometry: polygon,
+      },
+    },
+  });
+};
+
 module.exports = {
   createRiskPoint,
   createRiskPoints,
   findRiskPointsByBatchId,
   findRiskPointsNear,
+  findRiskPointsWithinPolygon,
 };


### PR DESCRIPTION
This change makes a single request to the database for all risk points near the route, then assigns risks based on the closest point. The old implementation hit the database once for each point along the route.