### PR TITLE
(refactor) Toggle toolbars based on interaction type (#93)

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -13,6 +13,7 @@
   "dependencies": {
     "axios": "^0.15.2",
     "chai": "^3.5.0",
+    "classnames": "^2.2.5",
     "colorcolor": "^1.1.1",
     "enzyme": "^2.6.0",
     "google-maps-react": "^1.0.19",
@@ -22,10 +23,10 @@
     "react-addons-test-utils": "^15.3.2",
     "react-dom": "^15.3.2",
     "react-redux": "^4.4.5",
-    "redux-thunk": "^2.1.0",
-    "redux": "^3.6.0",
     "react-router": "^3.0.0",
-    "react-tap-event-plugin": "^2.0.0"
+    "react-tap-event-plugin": "^2.0.0",
+    "redux": "^3.6.0",
+    "redux-thunk": "^2.1.0"
   },
   "scripts": {
     "start": "react-scripts start",

--- a/client/src/components/App/App.css
+++ b/client/src/components/App/App.css
@@ -7,3 +7,24 @@
 .floating-action-button-hide {
   display: none;
 }
+
+.first-card {
+  top: 11%;
+}
+
+.second-card {
+  top: 25%;
+  bottom: 0%;
+}
+
+.search-results-show {
+  position: absolute;
+  left: 5%;
+  right: 5%;
+  border-radius: 3px;
+}
+
+.search-results-hide {
+  display: none;
+}
+

--- a/client/src/components/App/App.css
+++ b/client/src/components/App/App.css
@@ -8,11 +8,28 @@
   display: none;
 }
 
-.first-card {
+.search-toolbar-show {
+  background-color: white !important;
+  position: absolute;
+  top: 2%;
+  left: 5%;
+  right: 5%;
+  border-radius: 3px;
+}
+
+.search-toolbar-hide {
+  display: none !important;
+}
+
+.searchbar-toolbar-group {
+  width: 100%;
+}
+
+.current-location-card {
   top: 11%;
 }
 
-.second-card {
+.search-results-card {
   top: 25%;
   bottom: 0%;
 }
@@ -26,5 +43,14 @@
 
 .search-results-hide {
   display: none;
+}
+
+.selecting-route-toolbar-show {
+  position: relative;
+  background-color: rgb(0, 188, 212) !important;
+}
+
+.selecting-route-toolbar-hide {
+  display: none !important;
 }
 

--- a/client/src/components/App/App.jsx
+++ b/client/src/components/App/App.jsx
@@ -1,5 +1,8 @@
 import React from 'react';
+import classNames from 'classnames';
 import { Toolbar, ToolbarGroup, ToolbarTitle } from 'material-ui/Toolbar';
+import { Card, CardActions, CardHeader, CardTitle, CardText } from 'material-ui/Card';
+import FlatButton from 'material-ui/FlatButton';
 import IconButton from 'material-ui/IconButton';
 import SearchBarHamburgerIcon from 'material-ui/svg-icons/navigation/menu';
 import OriginIcon from 'material-ui/svg-icons/device/gps-fixed';
@@ -17,6 +20,9 @@ import appHelper from '../utils/appHelper';
 injectTapEventPlugin();
 
 const App = (props) => {
+  let searchResultFirstCard = null;
+  let searchResultSecondCard = null;
+
   // These styles are for development only, remove for production
   const mapStyle = {};
   const appContainerStyle = {};
@@ -43,6 +49,21 @@ const App = (props) => {
     float: 'left',
   };
   const searchBarStyle = {};
+  // const firstCardStyle = {
+  //   position: 'absolute',
+  //   left: '5%',
+  //   right: '5%',
+  //   top: '11%',
+  //   borderRadius: '3px',
+  // };
+  // const secondCardStyle = {
+  //   position: 'absolute',
+  //   left: '5%',
+  //   right: '5%',
+  //   top: '25%',
+  //   bottom: '0%',
+  //   borderRadius: '3px',
+  // };
 
   const getSearchResults = (query) => {
     // get search results for query
@@ -57,6 +78,11 @@ const App = (props) => {
     SELECTING_ROUTE: 'SELECTING_ROUTE',
     VIEWING_SIDEBAR: 'VIEWING_SIDEBAR',
   };
+
+  const searchResultsCardsClasses = classNames({
+    'search-results-hide': props.interactionType !== interactionTypes.SEARCHING_DESTINATION && props.interactionType !== interactionTypes.SEARCHING_ORIGIN,
+    'search-results-show': props.interactionType === interactionTypes.SEARCHING_DESTINATION || props.interactionType === interactionTypes.SEARCHING_ORIGIN,
+  });
 
   return (
     <div className="app-container" style={appContainerStyle} >
@@ -113,6 +139,7 @@ const App = (props) => {
           />
         </Map>
       </div>
+
       <Toolbar className="search-toolbar" style={searchToolbarStyle}>
         <ToolbarGroup firstChild className="toolbar-group">
           <IconButton
@@ -135,11 +162,40 @@ const App = (props) => {
             dataSource={['INSERT_DATA_HERE']}
             style={searchBarStyle}
             onNewRequest={getSearchResults}
+            onClick={() => {
+              props.changeInteractionType('SEARCHING_DESTINATION');
+            }}
           />
         </ToolbarGroup>
       </Toolbar>
 
-      
+
+      <Card className={`${searchResultsCardsClasses} first-card`} ref={(c) => { searchResultFirstCard = c; }}>
+        <CardHeader
+          title="URL Avatar"
+          subtitle="Subtitle"
+          avatar="images/jsa-128.jpg"
+        />
+      </Card>
+
+      <Card className={`${searchResultsCardsClasses} second-card`} ref={(c) => { searchResultSecondCard = c; }}>
+        <CardHeader
+          title="URL Avatar"
+          subtitle="Subtitle"
+          avatar="images/jsa-128.jpg"
+        />
+        <CardTitle title="Card title" subtitle="Card subtitle" />
+        <CardText>
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+          Donec mattis pretium massa. Aliquam erat volutpat. Nulla facilisi.
+          Donec vulputate interdum sollicitudin. Nunc lacinia auctor quam sed pellentesque.
+          Aliquam dui mauris, mattis quis lacus id, pellentesque lobortis odio.
+        </CardText>
+        <CardActions>
+          <FlatButton label="Action1" />
+          <FlatButton label="Action2" />
+        </CardActions>
+      </Card>
 
       <FloatingActionButton className="floating-action-button-show">
         <MapsNavigation />

--- a/client/src/components/App/App.jsx
+++ b/client/src/components/App/App.jsx
@@ -1,7 +1,9 @@
 import React from 'react';
-import { Toolbar, ToolbarGroup } from 'material-ui/Toolbar';
+import { Toolbar, ToolbarGroup, ToolbarTitle } from 'material-ui/Toolbar';
 import IconButton from 'material-ui/IconButton';
 import SearchBarHamburgerIcon from 'material-ui/svg-icons/navigation/menu';
+import OriginIcon from 'material-ui/svg-icons/device/gps-fixed';
+import DestinationIcon from 'material-ui/svg-icons/communication/location-on';
 import AutoComplete from 'material-ui/AutoComplete';
 import injectTapEventPlugin from 'react-tap-event-plugin';
 import Map, { Marker } from 'google-maps-react';
@@ -26,9 +28,15 @@ const App = (props) => {
     left: '5%',
     right: '5%',
     borderRadius: '3px',
+    // display: 'none',
   };
   const searchToolbarGroupStyle = {
     width: '100%',
+    // display: 'none',
+  };
+  const selectingRouteToolbarStyle = {
+    position: 'relative',
+    backgroundColor: 'rgb(0, 188, 212)',
     // display: 'none',
   };
   const iconButtonStyle = {
@@ -57,6 +65,28 @@ const App = (props) => {
         width={300}
         open={props.interactionType === interactionTypes.VIEWING_SIDEBAR}
       />
+      <Toolbar style={selectingRouteToolbarStyle}>
+        <ToolbarGroup style={searchToolbarGroupStyle}>
+          <OriginIcon />
+          <AutoComplete
+            hintText="Origin"
+            fullWidth
+            dataSource={['INSERT_DATA_HERE']}
+            style={searchBarStyle}
+          />
+        </ToolbarGroup>
+      </Toolbar>
+      <Toolbar style={selectingRouteToolbarStyle}>
+        <ToolbarGroup style={searchToolbarGroupStyle}>
+          <DestinationIcon />
+          <AutoComplete
+            hintText="Destination"
+            fullWidth
+            dataSource={['INSERT_DATA_HERE']}
+            style={searchBarStyle}
+          />
+        </ToolbarGroup>
+      </Toolbar>
       <div className="map-container" style={mapContainerStyle}>
         <Map
           className="map"
@@ -108,6 +138,9 @@ const App = (props) => {
           />
         </ToolbarGroup>
       </Toolbar>
+
+      
+
       <FloatingActionButton className="floating-action-button-show">
         <MapsNavigation />
       </FloatingActionButton>

--- a/client/src/components/App/App.jsx
+++ b/client/src/components/App/App.jsx
@@ -20,50 +20,14 @@ import appHelper from '../utils/appHelper';
 injectTapEventPlugin();
 
 const App = (props) => {
-  let searchResultFirstCard = null;
-  let searchResultSecondCard = null;
-
   // These styles are for development only, remove for production
   const mapStyle = {};
   const appContainerStyle = {};
   const mapContainerStyle = {};
-  const searchToolbarStyle = {
-    backgroundColor: 'white',
-    position: 'absolute',
-    top: '2%',
-    left: '5%',
-    right: '5%',
-    borderRadius: '3px',
-    // display: 'none',
-  };
-  const searchToolbarGroupStyle = {
-    width: '100%',
-    // display: 'none',
-  };
-  const selectingRouteToolbarStyle = {
-    position: 'relative',
-    backgroundColor: 'rgb(0, 188, 212)',
-    // display: 'none',
-  };
   const iconButtonStyle = {
     float: 'left',
   };
   const searchBarStyle = {};
-  // const firstCardStyle = {
-  //   position: 'absolute',
-  //   left: '5%',
-  //   right: '5%',
-  //   top: '11%',
-  //   borderRadius: '3px',
-  // };
-  // const secondCardStyle = {
-  //   position: 'absolute',
-  //   left: '5%',
-  //   right: '5%',
-  //   top: '25%',
-  //   bottom: '0%',
-  //   borderRadius: '3px',
-  // };
 
   const getSearchResults = (query) => {
     // get search results for query
@@ -79,9 +43,19 @@ const App = (props) => {
     VIEWING_SIDEBAR: 'VIEWING_SIDEBAR',
   };
 
+  const searchBarToolbarClasses = classNames({
+    'search-toolbar-hide': props.interactionType === interactionTypes.SELECTING_ROUTE || props.interactionType === interactionTypes.VIEWING_SIDEBAR,
+    'search-toolbar-show': props.interactionType !== interactionTypes.SELECTING_ROUTE && props.interactionType !== interactionTypes.VIEWING_SIDEBAR,
+  });
+
   const searchResultsCardsClasses = classNames({
     'search-results-hide': props.interactionType !== interactionTypes.SEARCHING_DESTINATION && props.interactionType !== interactionTypes.SEARCHING_ORIGIN,
     'search-results-show': props.interactionType === interactionTypes.SEARCHING_DESTINATION || props.interactionType === interactionTypes.SEARCHING_ORIGIN,
+  });
+
+  const selectingRouteToolbarClasses = classNames({
+    'selecting-route-toolbar-hide': props.interactionType !== interactionTypes.SELECTING_ROUTE,
+    'selecting-route-toolbar-show': props.interactionType === interactionTypes.SELECTING_ROUTE,
   });
 
   return (
@@ -91,8 +65,11 @@ const App = (props) => {
         width={300}
         open={props.interactionType === interactionTypes.VIEWING_SIDEBAR}
       />
-      <Toolbar style={selectingRouteToolbarStyle}>
-        <ToolbarGroup style={searchToolbarGroupStyle}>
+      <Toolbar
+        className={selectingRouteToolbarClasses}
+        onClick={() => { props.changeInteractionType('SEARCHING_ORIGIN'); }}
+      >
+        <ToolbarGroup className="searchbar-toolbar-group">
           <OriginIcon />
           <AutoComplete
             hintText="Origin"
@@ -102,8 +79,11 @@ const App = (props) => {
           />
         </ToolbarGroup>
       </Toolbar>
-      <Toolbar style={selectingRouteToolbarStyle}>
-        <ToolbarGroup style={searchToolbarGroupStyle}>
+      <Toolbar
+        className={selectingRouteToolbarClasses}
+        onClick={() => { props.changeInteractionType('SEARCHING_DESTINATION'); }}
+      >
+        <ToolbarGroup className="searchbar-toolbar-group">
           <DestinationIcon />
           <AutoComplete
             hintText="Destination"
@@ -139,8 +119,7 @@ const App = (props) => {
           />
         </Map>
       </div>
-
-      <Toolbar className="search-toolbar" style={searchToolbarStyle}>
+      <Toolbar className={searchBarToolbarClasses}>
         <ToolbarGroup firstChild className="toolbar-group">
           <IconButton
             style={iconButtonStyle}
@@ -155,7 +134,7 @@ const App = (props) => {
             <SearchBarHamburgerIcon />
           </IconButton>
         </ToolbarGroup>
-        <ToolbarGroup className="toolbar-group" style={searchToolbarGroupStyle}>
+        <ToolbarGroup className="searchbar-toolbar-group">
           <AutoComplete
             hintText="Search"
             fullWidth
@@ -168,17 +147,20 @@ const App = (props) => {
           />
         </ToolbarGroup>
       </Toolbar>
-
-
-      <Card className={`${searchResultsCardsClasses} first-card`} ref={(c) => { searchResultFirstCard = c; }}>
+      <Card
+        className={`${searchResultsCardsClasses} current-location-card`}
+        onClick={() => { props.changeInteractionType('SELECTING_ROUTE'); }}
+      >
         <CardHeader
           title="URL Avatar"
           subtitle="Subtitle"
           avatar="images/jsa-128.jpg"
         />
       </Card>
-
-      <Card className={`${searchResultsCardsClasses} second-card`} ref={(c) => { searchResultSecondCard = c; }}>
+      <Card
+        className={`${searchResultsCardsClasses} search-results-card`}
+        onClick={() => { props.changeInteractionType('SELECTING_ROUTE'); }}
+      >
         <CardHeader
           title="URL Avatar"
           subtitle="Subtitle"
@@ -196,7 +178,6 @@ const App = (props) => {
           <FlatButton label="Action2" />
         </CardActions>
       </Card>
-
       <FloatingActionButton className="floating-action-button-show">
         <MapsNavigation />
       </FloatingActionButton>


### PR DESCRIPTION
The origin/destination toolbar is currently toggled onClick on a search result card (so we can see that it is working). This should be refactored later to only be toggled onClick on an actual search result only and not the whole card.

Also still need to fill out the search results cards with the correct information.