### PR TITLE
(fix) Fix what view user is taken to after sidebar closes

### DIFF
--- a/client/src/components/App/App.jsx
+++ b/client/src/components/App/App.jsx
@@ -94,11 +94,7 @@ const App = (props) => {
         <IconButton
           style={iconButtonStyle}
           onClick={() => (
-            appHelper.toggleInteractionTypeFromMenuClick(
-              props.interactionType,
-              props.changeInteractionType,
-              interactionTypes,
-            )
+            appHelper.toggleInteractionTypeFromMenuClick(props, interactionTypes)
           )}
         >
           <Close color="rgb(0, 188, 212)" />
@@ -178,8 +174,7 @@ const App = (props) => {
             style={iconButtonStyle}
             onClick={() => (
               appHelper.toggleInteractionTypeFromMenuClick(
-                props.interactionType,
-                props.changeInteractionType,
+                props,
                 interactionTypes,
               )
             )}

--- a/client/src/components/utils/appHelper.js
+++ b/client/src/components/utils/appHelper.js
@@ -101,14 +101,19 @@ const toggleFloatingActionButtonClass = (interactionType, interactionTypes) => (
   interactionType === interactionTypes.SELECTING_ROUTE ? 'floating-action-button-show' : 'floating-action-button-hide'
 );
 
-const toggleInteractionTypeFromMenuClick = (currentInteractionType, dispatcher, interactionTypes) => {
-  if (currentInteractionType !== interactionTypes.VIEWING_SIDEBAR) {
-    dispatcher(interactionTypes.VIEWING_SIDEBAR);
+const toggleInteractionTypeFromMenuClick = (props, interactionTypes) => {
+  // If sidebar is currently not open, open sidebar
+  if (props.interactionType !== interactionTypes.VIEWING_SIDEBAR) {
+    return props.changeInteractionType(interactionTypes.VIEWING_SIDEBAR);
   }
 
-  if (currentInteractionType === interactionTypes.VIEWING_SIDEBAR) {
-    dispatcher(interactionTypes.VIEWING_MAP);
+  // If origin and destination has been set, transition to SELECTING_ROUTE view from sidebar
+  if (props.interactionType === interactionTypes.VIEWING_SIDEBAR && props.origin && props.destination) {
+    return props.changeInteractionType(interactionTypes.SELECTING_ROUTE);
   }
+
+  // If none of the above, go back to VIEWING_MAP
+  return props.changeInteractionType(interactionTypes.VIEWING_MAP);
 };
 
 const useCurrentLocationClickHandler = (props, interactionTypes) => {


### PR DESCRIPTION
User was not returned to the correct view if the sidebar was opened from search results view.

Wrote logic to take user to SELECTING_ROUTE view if destination and origin has been set already.
Otherwise, user will be taken to the VIEWING_MAP view.