### PR TITLE
(fix) Correct error where maps URL was incorrect

### DIFF
--- a/tripService/logger.js
+++ b/tripService/logger.js
@@ -1,0 +1,15 @@
+const winston = require('winston');
+const path = require('path');
+
+module.exports = new (winston.Logger)({
+  transports: [
+    new (winston.transports.Console)({
+      colorize: true,
+    }),
+    new (winston.transports.File)({
+      filename: path.join(__dirname, 'tripService.log'),
+      colorize: false,
+      json: false,
+    }),
+  ],
+});

--- a/tripService/requestHandlers.js
+++ b/tripService/requestHandlers.js
@@ -6,6 +6,7 @@ const getPaths = require('./tripHelpers.js').getPaths;
 const generateDirectionsURL = require('./tripHelpers.js').generateDirectionsURL;
 const generateTravelTime = require('./tripHelpers.js').generateTravelTime;
 const generateTravelDistance = require('./tripHelpers.js').generateTravelDistance;
+const logger = require('./logger');
 
 const APIKEY = process.env.APIKEY;
 
@@ -28,7 +29,10 @@ const requestRoutes = (origin, destination, waypoints) => {
     },
   })
   .then(response => response.data)
-  .catch((error) => { throw new Error(`Error requesting Route with origin ${origin}, and destination ${destination}: ${error.message}`); });
+  .catch((error) => {
+    logger.error((`Error requesting Route with origin ${origin}, and destination ${destination}: ${error.message}`));
+    throw new Error(`Error requesting Route with origin ${origin}, and destination ${destination}: ${error.message}`);
+  });
 };
 
 
@@ -61,7 +65,14 @@ const requestHandler = (request, response) => {
     }));
   })
   .then(responseArray => response.status(200).json(responseArray))
-  .catch(error => response.status(400).json({ error: { message: `There was an error getting directions: ${error.message}.` } }));
+  .catch((error) => {
+    logger.error(`Response handler error: ${error}`);
+    return response.status(400).json({
+      error: {
+        message: `There was an error getting directions: ${error.message}`,
+      },
+    });
+  });
 };
 
 

--- a/tripService/server.js
+++ b/tripService/server.js
@@ -1,7 +1,9 @@
 const express = require('express');
 const bodyParser = require('body-parser');
 const morgan = require('morgan');
+const path = require('path');
 const requestHandler = require('./requestHandlers.js').requestHandler;
+const logger = require('./logger');
 
 const app = express();
 
@@ -11,10 +13,10 @@ app.use(morgan('dev'));
 
 app.post('/routes', requestHandler);
 
+app.use('/logs', express.static(path.join(__dirname, 'tripService.log')));
+
 const port = 3001;
 
-app.listen(port, () => {
-  console.log('listening on port 3001...');
-});
+app.listen(port, () => logger.info(`Trip service listening on ${port}`));
 
 module.exports = app;

--- a/tripService/tripHelpers.js
+++ b/tripService/tripHelpers.js
@@ -1,6 +1,5 @@
 const polyline = require('polyline');
 const turf = require('turf');
-const path = require('path');
 // The following functions convert the directioss object recieved from the googleMaps API into
 // an array of coordinates along the path.
 // The array of coordinates are separated by a prescribed threshold.
@@ -39,14 +38,14 @@ const generateTravelDistance = (legs) => {
 };
 
 const generateDirectionsURL = (legs) => {
-  const url = 'https://www.google.com/maps/dir';
+  const googleMapsUrl = 'https://www.google.com/maps/dir';
   const suffix = 'data=!3m1!4b1!4m2!4m1!3e2';
   const coords = [];
   legs.forEach((leg) => {
     coords.push(`${leg.start_location.lat},${leg.start_location.lng}`);
   });
   coords.push(`${legs[legs.length - 1].end_location.lat},${legs[legs.length - 1].end_location.lng}`);
-  return path.join(url, coords.join('/'), suffix);
+  return `${googleMapsUrl}/${coords.join('/')}/${suffix}`;
 };
 
 // const getWaypoints = (legs) => {


### PR DESCRIPTION
Path.join() was causing 'http://www.goo....' to be put out as 'http:/www.goo..'. Replaced with string template. Added logger.